### PR TITLE
minor fixes to readme, tweak networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Arteria pack. You only need to do this the first time you bring up the environme
 # Copy the default config into the StackStorm config directory
 cp /opt/stackstorm/packs/arteria/default.config.yaml /opt/stackstorm/configs/arteria.yaml
 
+# Register packs and configuration values
+st2ctl reload --register-all
+
 # Ensure that the Arteria virtual env is installed
 st2 run packs.setup_virtualenv packs=arteria
-
-# Register the new configuration values
-st2ctl reload --register-configs
 ```
 
 Now the environment should be ready to run a workflow.
@@ -140,5 +140,5 @@ Running tests
 To run the pack tests, run the following command in the StackStorm container:
 
 ```
-st2-run-pack-tests -c -j -v -p /opt/stackstorm/packs/arteria
+st2-run-pack-tests -c -v -p /opt/stackstorm/packs/arteria
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ st2 rule enable arteria.when_runfolder_is_ready_start_bcl2fastq
 Then to start processing the runfolder, set its state to `ready` using:
 
 ```
-st2 run arteria.runfolder-service cmd="set_state" state="ready" runfolder="/opt/monitored-folder/<name of your runfolder>" url="http://runfolder-service"
+st2 run arteria.runfolder_service cmd="set_state" state="ready" runfolder="/opt/monitored-folder/<name of your runfolder>" url="http://runfolder-service"
 ```
 
 Withing 15s you should if you execute `st2 execution list` see that a workflow processing that runfolder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - docker-conf/postgres.env
       - docker-conf/redis.env
     ports:
-      - "443:443"
+      - 443
     networks:
       - public
       - private
@@ -120,3 +120,4 @@ networks:
     driver: bridge
   private:
     driver: bridge
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - docker-conf/postgres.env
       - docker-conf/redis.env
     ports:
-      - 443
+      - "443:443"
     networks:
       - public
       - private


### PR DESCRIPTION
:+1:
This is a great entrypoint for getting up and running in a breeze! I found a few snags that I hope are fixed in this PR. It's quite new territory for me though, so they may very well be things I just have misunderstood.. 🙄 

I had to explicitly register the packs to be able to run the actions so I included that in the instructions. Perhaps that can be moved to the deployment scripts or something like that.

I had some networking issues because of port collisions on my host. I think I solved it by making the private network internal.

Also, docker-compose would set up the stackstorm master port forwarding on the host for port 443 on the external interface, which maybe is the intention but I wasn't expecting that for just running the PoC setup, so I changed that. Let me know what you think. 
